### PR TITLE
Fix xgettext encoding option

### DIFF
--- a/.sh.d/01_nvda2svn.sh
+++ b/.sh.d/01_nvda2svn.sh
@@ -7,6 +7,7 @@ makePot() {
     xgettext -o $potName \
         --package-name NVDA --package-version "$version" \
         --foreign-user --add-comments=Translators: --keyword=pgettext:1c,2 \
+        --from-code utf-8 \
         --language=python \
         *.py *.pyw */*.py */*/*.py
     cd $origDir


### PR DESCRIPTION
Since https://github.com/nvaccess/nvda/pull/11081 it is expected that
xgettext should be run by manually specifying the file encoding.

There is currently a in-place fix for this on the NV Access server, this will need to be removed.
Eg `git checkout --  .sh.d/01_nvda2svn.sh` from the `~/mr` folder for `nvdal10n`